### PR TITLE
fix(firewall): restore working devcontainer firewall

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,9 @@
     "--cap-add=NET_ADMIN",
     "--cap-add=NET_RAW"
   ],
+  "containerEnv": {
+    "CI": "${localEnv:CI}"
+  },
   "customizations": {
     "vscode": {
       "extensions": [],
@@ -18,11 +21,10 @@
     }
   },
   "postCreateCommand": {
-    "apt": "sudo apt-get update && sudo apt-get install -y iptables ipset dnsutils aggregate",
+    "system": "sudo apt-get update && sudo apt-get install -y iptables ipset dnsutils aggregate && sudo ${containerWorkspaceFolder}/.devcontainer/init-firewall.sh",
     "python": "pip install uv && uv tool install llm && llm install llm-github-models llm-anthropic llm-gemini && llm models default github/gpt-4.1",
     "node": "npm install -g @anthropic-ai/claude-code rust-just @earendil-works/pi-coding-agent",
-    "go": "go install github.com/charmbracelet/glow/v2@latest",
-    "firewall": "sudo ${containerWorkspaceFolder}/.devcontainer/init-firewall.sh || true"
+    "go": "go install github.com/charmbracelet/glow/v2@latest"
   },
   "remoteUser": "vscode"
 }

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -74,7 +74,6 @@ for domain in \
     "registry.npmjs.org" \
     "api.anthropic.com" \
     "sentry.io" \
-    "statsig.anthropic.com" \
     "statsig.com" \
     "marketplace.visualstudio.com" \
     "vscode.blob.core.windows.net" \


### PR DESCRIPTION
Two commits that together restore the devcontainer firewall to a
working state in Codespaces and stop hiding failures from us.

1. fix(firewall): remove NXDOMAIN statsig.anthropic.com from allowlist
   Subdomain returns NXDOMAIN (verified 2026-05-12). Combined with
   `set -euo pipefail`, this was aborting init-firewall.sh before
   any DROP policies were applied, leaving the container open.

2. fix(devcontainer): make firewall failures visible and CI-aware
   - Propagate CI env var into the container so the script's
     existing CI skip fires inside devcontainers/ci builds.
   - Chain apt and firewall sequentially (they previously raced).
   - Remove `|| true`; failures now propagate. Matches upstream
     Anthropic's posture.

Upstream Anthropic init-firewall.sh has the same NXDOMAIN bug.
Plan to file an issue there as a follow-up.
