### PR TITLE
fix(firewall): reset iptables policies before flushing rules

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -11,6 +11,13 @@ fi
 # 1. Extract Docker DNS info BEFORE any flushing
 DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
 
+# Reset policies to ACCEPT before flushing — otherwise a re-run strips the
+# ACCEPT rules while DROP remains, bricking the container on partial failure.
+# See `git log` for full rationale.
+iptables -P INPUT ACCEPT
+iptables -P FORWARD ACCEPT
+iptables -P OUTPUT ACCEPT
+
 # Flush existing rules and delete existing ipsets
 iptables -F
 iptables -X


### PR DESCRIPTION
On the first run of `init-firewall.sh` the policy reset is a no-op (default policies start as ACCEPT). On a re-run — which the README documents as the workflow for picking up new allowlisted domains — the previous successful run has set policies to DROP. Flushing without first resetting them strips every ACCEPT rule while DROP remains, leaving the container without working egress until the script finishes rebuilding. Any failure between flush and rebuild (slow DNS, transient GitHub API timeout, edit-introduced typo) bricks the container.

Three lines added before the existing flush block reset policies to ACCEPT first. The brief window of permissiveness is the same state as a fresh container before the script ran, so no new exposure.

**Manual validation** (CI can't exercise — script skips when `CI=true`): in a Codespace built from this branch, run `sudo bash .devcontainer/init-firewall.sh` twice in a row, then confirm `curl --connect-timeout 5 https://api.github.com/zen` succeeds.

See commit message for full rationale.
