### PR TITLE
fix(tests): make test_connectivity.sh actually fail when checks fail

### DIFF
--- a/tests/network/test_connectivity.sh
+++ b/tests/network/test_connectivity.sh
@@ -1,49 +1,78 @@
- #!/bin/bash
- # Network connectivity test for Claude Codespace dependencies
- # Following TDD principles - establish baseline before firewall implementation
+#!/bin/bash
+# Network connectivity test for Safer Codespace.
+#
+# Verifies that the endpoints required by .devcontainer/devcontainer.json's
+# postCreateCommand are reachable at the TCP layer from the current environment.
+# Uses bash /dev/tcp probes (same idiom as tests/codespace/verify-firewall.sh)
+# rather than HTTP requests, to avoid false positives from middleboxes returning
+# 403 — the previous version of this script used bare `curl -s` (no --fail)
+# and so accepted 403/404 responses as "CONNECTED - TEST PASSED" while never
+# emitting a non-zero exit code. The CI badge has been green by construction.
+#
+# Designed to run on a bare CI runner (no firewall active). Firewall behavior
+# is verified separately by tests/codespace/verify-firewall.sh.
+#
+# Exit codes:
+#   0  all required endpoints reachable at TCP layer
+#   1  one or more endpoints not reachable
 
- echo "=== Claude Codespace Network Connectivity Test ==="
- echo "Testing endpoints required by postCreateCommand tools..."
- echo
+set -uo pipefail
+# Deliberately not using `set -e` — we want individual probe failures to be
+# reported and counted, not to abort the whole test.
 
- # Core endpoints from your devcontainer.json postCreateCommand
- endpoints=(
-     "PyPI (pip/uv):https://pypi.org/simple/"
-     "GitHub API:https://api.github.com"
-     "GitHub Models:https://models.inference.ai.azure.com"
-     "Anthropic API:https://api.anthropic.com"
-     "Gemini API:https://generativelanguage.googleapis.com"
-     "npm registry:https://registry.npmjs.org"
-     "Go modules:https://proxy.golang.org"
- )
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILED_ENDPOINTS=()
 
- # Test each endpoint
- for endpoint in "${endpoints[@]}"; do
-     name="${endpoint%%:*}"
-     url="${endpoint#*:}"
+echo "=== Safer Codespace network connectivity test ==="
+echo "Checking TCP/443 reachability for endpoints required by postCreateCommand..."
+echo
 
-     printf "Testing %-25s " "$name:"
-     if curl -s --connect-timeout 5 --max-time 10 "$url" > /dev/null 2>&1; then
-         echo "CONNECTED - TEST PASSED"
-     else
-         echo "NOT REACHABLE - TEST FAILED"
-     fi
- done
+# Format: "Display Name:host:port" — split on ':' below.
+# These hosts must be reachable for the devcontainer to build and the
+# preinstalled tools (uv/pip, npm, go, llm, claude-code) to function.
+endpoints=(
+    "PyPI:pypi.org:443"
+    "GitHub API:api.github.com:443"
+    "GitHub Models:models.inference.ai.azure.com:443"
+    "Anthropic API:api.anthropic.com:443"
+    "Gemini API:generativelanguage.googleapis.com:443"
+    "npm registry:registry.npmjs.org:443"
+    "Go modules:proxy.golang.org:443"
+)
 
- # Test additional endpoints that should not be reachable based on firewall rules, e.g www.example.com
-    echo "Testing endpoints that should NOT be reachable if firewall is turned on..."
-    unreachable_endpoints=(
-        "Example Domain:http://www.example.com"
-    )
+for endpoint in "${endpoints[@]}"; do
+    name="${endpoint%%:*}"
+    rest="${endpoint#*:}"
+    host="${rest%%:*}"
+    port="${rest#*:}"
 
-    for endpoint in "${unreachable_endpoints[@]}"; do
-        name="${endpoint%%:*}"
-        url="${endpoint#*:}"
+    printf "  %-22s " "$name:"
 
-        printf "Testing %-25s " "$name:"
-        if curl -s --connect-timeout 5 --max-time 10 "$url" > /dev/null 2>&1; then
-            echo "CONNECTED - Devcontainer firewall is turned off or not working as expected!"
-        else
-            echo "NOT REACHABLE - Devcontainer firewall is working as expected!"
-        fi
+    if timeout 5 bash -c "</dev/tcp/$host/$port" 2>/dev/null; then
+        echo "OK"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "FAIL (TCP connection failed)"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        FAILED_ENDPOINTS+=("$name ($host:$port)")
+    fi
+done
+
+echo
+echo "=== Summary ==="
+echo "  Passed: $PASS_COUNT"
+echo "  Failed: $FAIL_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo
+    echo "Failed endpoints:"
+    for endpoint in "${FAILED_ENDPOINTS[@]}"; do
+        echo "  - $endpoint"
     done
+    exit 1
+fi
+
+echo
+echo "All required endpoints reachable."
+exit 0


### PR DESCRIPTION
The script had three combining bugs that made the CI badge green by construction:

- No `exit 1`, no `set` flags, no failure counter — script always exited 0.
- Bare `curl -s` (no `--fail`) accepted 4xx responses as success. Empirically, 5 of 7 "should be reachable" endpoints return 4xx to anonymous requests and were marked `CONNECTED - TEST PASSED`.
- Byte 0 was a space, so the shebang did not parse under strict kernel rules.

Rewrites with `/dev/tcp` probes (same idiom as `verify-firewall.sh`). TCP-level reachability is the right scope here — application-layer behavior of each endpoint is irrelevant to whether the postCreateCommand tools work.

Also drops the example.com negative control (perpetually "firewall is off" on a bare CI runner with no firewall; `verify-firewall.sh` already does negative controls correctly in a Codespace context).

**Expected CI behavior:** all 7 endpoints reachable on `ubuntu-latest`, exit 0. If any TCP/443 path is blocked, the script now exits 1 and the workflow turns red.
