### PR TITLE
fix(firewall): restrict DNS egress to configured resolvers

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -37,13 +37,45 @@ else
     echo "No Docker DNS rules to restore"
 fi
 
-# First allow DNS and localhost before any restrictions
-# Allow outbound DNS
-iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
-# Allow inbound DNS responses
-iptables -A INPUT -p udp --sport 53 -j ACCEPT
-# Note: upstream adds blanket outbound SSH rules here (TCP/22 OUTPUT, plus a
-# return-traffic INPUT). Omitted in this fork — TCP/22 to any destination is
+# Restrict DNS egress to the resolvers actually configured for this container.
+# Closes the direct DNS-tunnel exfiltration channel where a compromised agent
+# encodes data in subdomain labels of queries directed at an attacker-controlled
+# nameserver. Does NOT prevent exfiltration through the legitimate resolver
+# chain (the upstream resolver still recurses to whatever NS the attacker's
+# domain points at) — that would require application-layer DNS filtering,
+# which is out of scope for an iptables-based control.
+#
+# Reads /etc/resolv.conf plus /run/systemd/resolve/resolv.conf (the latter
+# only if present). Both are needed in environments using systemd-resolved
+# as a stub: /etc/resolv.conf points at 127.0.0.53 on loopback (already
+# covered by the lo rule below, but explicit allow doesn't hurt), and
+# /run/systemd/resolve/resolv.conf lists the *upstream* resolvers that
+# systemd-resolved forwards to — those queries leave via eth0 and hit
+# OUTPUT, so they need their own allow rule.
+#
+# TCP/53 is included because DNS responses larger than 512 bytes (DNSSEC,
+# big answer sets) fall back to TCP.
+RESOLVER_FILES=("/etc/resolv.conf")
+[ -r /run/systemd/resolve/resolv.conf ] && RESOLVER_FILES+=("/run/systemd/resolve/resolv.conf")
+resolvers=$(cat "${RESOLVER_FILES[@]}" 2>/dev/null | awk '/^nameserver/ {print $2}' | sort -u)
+if [ -z "$resolvers" ]; then
+    echo "ERROR: no nameservers found in ${RESOLVER_FILES[*]} — refusing to apply firewall with no DNS path"
+    exit 1
+fi
+echo "Allowing DNS to configured resolvers:"
+for resolver in $resolvers; do
+    echo "  - $resolver"
+    iptables -A OUTPUT -p udp --dport 53 -d "$resolver" -j ACCEPT
+    iptables -A OUTPUT -p tcp --dport 53 -d "$resolver" -j ACCEPT
+done
+
+# Note: upstream init-firewall.sh has `iptables -A INPUT -p udp --sport 53 -j
+# ACCEPT` here to accept DNS responses. Removed in this fork — source ports
+# are spoofable, and the ESTABLISHED,RELATED rule added later in this script
+# handles return traffic correctly via connection tracking.
+#
+# Note: upstream also adds blanket outbound SSH rules here (TCP/22 OUTPUT, plus
+# a return-traffic INPUT). Omitted in this fork — TCP/22 to any destination is
 # an allowlist bypass since SSH can tunnel arbitrary traffic. SSH to GitHub
 # still works via the allowed-domains ipset; other hosts require explicit
 # allowlisting. See `git log` for the full rationale.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This devcontainer comes pre-configured with:
 - **[just](https://just.systems/)** - Simple command runner (like make, but better)
 
 ### Security Features
-- **Network firewall** - Blocks unauthorized outbound connections (auto-configured). The allowlist covers SSH as well as HTTP/S, so `ssh` to non-allowlisted hosts is blocked. GitHub-over-SSH works out of the box because GitHub's SSH endpoints are included via the `api.github.com/meta` fetch.
+- **Network firewall** - Blocks unauthorized outbound connections (auto-configured). The allowlist covers SSH as well as HTTP/S, so `ssh` to non-allowlisted hosts is blocked. GitHub-over-SSH works out of the box because GitHub's SSH endpoints are included via the `api.github.com/meta` fetch. **DNS egress is restricted to the resolvers configured in `/etc/resolv.conf` and `/run/systemd/resolve/resolv.conf`**, closing direct DNS-tunnel exfiltration to attacker-controlled nameservers (DNS through the legitimate resolver chain is not closed — that would need application-layer DNS filtering, out of scope for an iptables-based control).
 - **Content segregation** - Separate `context/trusted/` and `context/untrusted/` directories
 - **No GitHub CLI** - Intentionally excluded to prevent potential data exfiltration
 

--- a/tests/codespace/verify-firewall.sh
+++ b/tests/codespace/verify-firewall.sh
@@ -89,6 +89,13 @@ run_check "TCP/22 to 1.1.1.1 (Cloudflare, non-GitHub)" "fail" \
     "timeout 5 bash -c '</dev/tcp/1.1.1.1/22'"
 run_check "TCP/22 to gitlab.com (non-GitHub host)" "fail" \
     "timeout 5 bash -c '</dev/tcp/gitlab.com/22'"
+# DNS to a resolver not in /etc/resolv.conf or /run/systemd/resolve/resolv.conf
+# should be blocked. 9.9.9.9 (Quad9) is a real working resolver — so if dig
+# succeeds, it means the firewall didn't restrict destination. Picked Quad9
+# rather than 1.1.1.1 or 8.8.8.8 because Codespaces is least likely to have
+# Quad9 as its configured upstream. If your environment does, swap for another.
+run_check "DNS to 9.9.9.9 (Quad9, not in resolver config)" "fail" \
+    "timeout 3 dig +time=2 +tries=1 @9.9.9.9 example.com"
 
 echo
 echo "=== Summary ==="


### PR DESCRIPTION
The previous rule allowed UDP/53 to any destination — a textbook DNS-tunneling exfiltration channel (an agent encodes data in subdomain labels of queries to an attacker-controlled nameserver; tools like `iodine` and `dnscat2` automate this).

Replaces the wildcard with per-resolver ACCEPT rules sourced dynamically from `/etc/resolv.conf` and (if present) `/run/systemd/resolve/resolv.conf`. The second file matters in environments using `systemd-resolved` as a stub (Codespaces): `/etc/resolv.conf` points at 127.0.0.53 on loopback, but the stub's upstream queries leave via eth0 and hit OUTPUT, so they need their own allow rule. TCP/53 is included alongside UDP/53 for DNSSEC and large-answer fallback.

**Honest scoping:** this closes the *direct*-DNS-to-attacker channel. It does NOT prevent exfil through the legitimate resolver chain (a query for `secret-data.attacker.example` still gets forwarded upstream by the stub and reaches the attacker's auth NS). That gap requires application-layer DNS filtering, out of scope.

**Edge case handled:** if no nameservers are found in either file, the script exits 1 rather than apply default-DROP with no DNS path.

Also removes the redundant `INPUT -p udp --sport 53` rule from upstream — source ports are spoofable, and the `ESTABLISHED,RELATED` rule later in the script handles return DNS traffic correctly via conntrack.

`verify-firewall.sh` extended with a negative DNS control (`dig @9.9.9.9` should fail). Chose Quad9 over 1.1.1.1/8.8.8.8 because Codespaces is least likely to have it configured as the upstream (would cause a false negative). README's Security Features bullet updated.

**Manual validation** (CI can't exercise — script skips when `CI=true`): in a Codespace built from this branch, expect 4 positive + 4 negative controls all OK. The existing `getent hosts github.com` positive validates the happy path through the configured resolver; the new `dig @9.9.9.9` negative validates the new restriction.
