### PR TITLE
fix(firewall): allow documentation domains used by url_to_markdown

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -152,7 +152,18 @@ CRITICAL_DOMAINS=(
 )
 
 # Optional domains: failure is logged and skipped.
+#
+# Two groups:
+#   1. Tooling endpoints needed by the preinstalled tools (uv/pip, npm, go,
+#      llm, claude-code, copilot, VS Code).
+#   2. Documentation sites supported by cli-tools/url_to_markdown.py. These
+#      MUST stay in sync with that script's ALLOWED_DOMAINS set — otherwise
+#      the tool's whole workflow (fetch external docs into context/untrusted/
+#      for human review) silently fails when the firewall is active. Doc
+#      sites are low-exfil-risk targets (no general POST endpoint accepting
+#      arbitrary data), so this surface increase is bounded.
 OPTIONAL_DOMAINS=(
+    # --- Group 1: tooling endpoints ---
     "registry.npmjs.org"
     "sentry.io"
     "statsig.com"
@@ -166,6 +177,39 @@ OPTIONAL_DOMAINS=(
     "proxy.golang.org"
     "sum.golang.org"
     "api.githubcopilot.com"
+
+    # --- Group 2: documentation sites for url_to_markdown.py ---
+    # Python
+    "docs.python.org"
+    # JavaScript / Node (pypi.org already in Group 1)
+    "developer.mozilla.org"
+    "docs.npmjs.com"
+    "nodejs.org"
+    # Other languages
+    "docs.oracle.com"          # Java
+    "learn.microsoft.com"      # .NET, Azure docs, etc.
+    # Frameworks
+    "react.dev"
+    "vuejs.org"
+    "flask.palletsprojects.com"
+    "docs.djangoproject.com"
+    # Version control & DevOps (api.github.com already covered via IP ranges)
+    "docs.github.com"
+    "docs.gitlab.com"
+    # Databases
+    "postgresql.org"
+    "dev.mysql.com"
+    "mongodb.com"
+    # LLM / AI
+    "llm.datasette.io"
+    "datasette.io"
+    "platform.openai.com"
+    "docs.claude.com"
+    "ai.google.dev"
+    # Cloud provider docs
+    "cloud.google.com"
+    "aws.amazon.com"
+    "azure.microsoft.com"
 )
 
 for domain in "${CRITICAL_DOMAINS[@]}"; do

--- a/cli-tools/url_to_markdown.py
+++ b/cli-tools/url_to_markdown.py
@@ -31,8 +31,13 @@ import lxml.html
 from lxml.html.clean import Cleaner
 
 
-# SECURITY: Allow-list of trusted documentation domains
-# These are known documentation sites for software development
+# SECURITY: Allow-list of trusted documentation domains.
+# These are known documentation sites for software development.
+#
+# This list MUST stay in sync with the "Group 2: documentation sites" section
+# of OPTIONAL_DOMAINS in .devcontainer/init-firewall.sh — otherwise the
+# firewall blocks egress to most entries here and the tool silently fails
+# when run inside the devcontainer.
 ALLOWED_DOMAINS: set[str] = {
     # Python
     'docs.python.org',

--- a/tests/codespace/verify-firewall.sh
+++ b/tests/codespace/verify-firewall.sh
@@ -77,6 +77,17 @@ run_check "TCP/22 to github.com (SSH endpoint)" "pass" \
     "timeout 5 bash -c '</dev/tcp/github.com/22'"
 run_check "DNS resolution of github.com" "pass" \
     "getent hosts github.com"
+# Representative sample of documentation domains used by cli-tools/url_to_markdown.py.
+# The full list lives in OPTIONAL_DOMAINS in .devcontainer/init-firewall.sh, grouped
+# as "documentation sites for url_to_markdown.py". One check per category (Python,
+# LLM/AI, cloud/enterprise) — sufficient evidence that the firewall is allowing the
+# documentation tier as a whole without bloating the test suite with 24+ checks.
+run_check "HTTPS to docs.python.org (Python docs)" "pass" \
+    "curl --connect-timeout 5 -fsS -o /dev/null https://docs.python.org/3/"
+run_check "HTTPS to docs.claude.com (LLM/AI docs)" "pass" \
+    "curl --connect-timeout 5 -fsS -o /dev/null https://docs.claude.com/"
+run_check "HTTPS to learn.microsoft.com (cloud/.NET docs)" "pass" \
+    "curl --connect-timeout 5 -fsS -o /dev/null https://learn.microsoft.com/"
 
 echo
 echo "=== Negative controls (non-allowlisted destinations should be blocked) ==="


### PR DESCRIPTION
`cli-tools/url_to_markdown.py` exists to fetch external docs into `context/untrusted/` for human review. Its 25-entry `ALLOWED_DOMAINS` set had only one entry (`pypi.org`) overlapping with the firewall allowlist — so the tool silently failed against almost every domain in its own allowlist whenever the firewall was active. Last session's PR fixed the tool's stale output-path bug; this PR closes the network-reachability gap.

Shipped as two commits to make the TDD discipline visible:

1. **`chore(tests):`** adds three representative positive controls to `verify-firewall.sh` (one per category in the new allowlist group: Python, LLM/AI, cloud/.NET).
2. **`fix(firewall):`** adds the 24 doc domains to `OPTIONAL_DOMAINS` in `init-firewall.sh` plus a reciprocal cross-reference comment in `url_to_markdown.py`.

## Verification evidence

After commit 1 (test additions only), Codespace built fresh on this branch:

```
=== Positive controls (allowlisted destinations should succeed) ===
  HTTPS to api.github.com                              OK
  TCP/22 to github.com (SSH endpoint)                  OK
  DNS resolution of github.com                         OK
  HTTPS to docs.python.org (Python docs)               OK
  HTTPS to docs.claude.com (LLM/AI docs)               OK
  HTTPS to learn.microsoft.com (cloud/.NET docs)       FAIL (expected pass, got fail)
=== Negative controls (non-allowlisted destinations should be blocked) ===
  HTTPS to example.com                                 OK
  TCP/22 to 1.1.1.1 (Cloudflare, non-GitHub)           OK
  TCP/22 to gitlab.com (non-GitHub host)               OK
  DNS to 9.9.9.9 (Quad9, not in resolver config)       OK
=== Summary ===
  Passed: 9
  Failed: 1
```

After commit 2 (allowlist expansion) + re-running `sudo bash .devcontainer/init-firewall.sh` in the same Codespace to pick up the new entries without rebuild:

```
=== Positive controls (allowlisted destinations should succeed) ===
  HTTPS to api.github.com                              OK
  TCP/22 to github.com (SSH endpoint)                  OK
  DNS resolution of github.com                         OK
  HTTPS to docs.python.org (Python docs)               OK
  HTTPS to docs.claude.com (LLM/AI docs)               OK
  HTTPS to learn.microsoft.com (cloud/.NET docs)       OK
=== Negative controls (non-allowlisted destinations should be blocked) ===
  HTTPS to example.com                                 OK
  TCP/22 to 1.1.1.1 (Cloudflare, non-GitHub)           OK
  TCP/22 to gitlab.com (non-GitHub host)               OK
  DNS to 9.9.9.9 (Quad9, not in resolver config)       OK
=== Summary ===
  Passed: 10
  Failed: 0
```

## Interesting finding: two of three "should be blocked" checks were already passing pre-fix

The TDD discipline surfaced a real architectural limitation. Of the three doc domains we expected to be blocked before commit 2 landed, only `learn.microsoft.com` was actually blocked. The other two were reachable via CDN-shared-IP overlap with existing allowlist entries:

- `docs.claude.com` → `160.79.104.10` — same IP as `api.anthropic.com`. Reachable pre-fix because the IP was already in the ipset.
- `docs.python.org` → `151.101.0.223` (Fastly) — shares IP pool with `pypi.org` and `files.pythonhosted.org`. Reachable pre-fix for the same reason.
- `learn.microsoft.com` → `2.22.46.87` (Akamai) — does not share IPs with any existing allowlist entry, so it was genuinely blocked.

**Implication:** IP-based allowlisting cannot reliably control reachability for hostnames sharing CDN infrastructure. This is the "shared-IP bypass" flagged in the 2026-05-15 review pass. The fix is still substantively right (explicit allowlisting is more robust than accidental CDN-IP overlap, which can drift), but this is concrete empirical evidence for the eventual hostname-aware-proxy RFC.

## Tradeoffs

- **Surface increase is bounded.** Doc sites have no general POST endpoint accepting arbitrary client data, so adding them to the allowlist doesn't meaningfully widen the exfiltration surface beyond what's already present via the LLM API endpoints.
- **`OPTIONAL` classification.** A DNS failure for any individual doc domain (CDN drift, regional outage) warn-and-continues rather than aborting firewall init.
- **Two separate allowlists kept manually in sync.** Documented on both sides via cross-reference comments. Factoring out a shared source of truth would be over-engineering for 25 entries.
- **Workflow note:** after this lands, contributors editing the doc list need to either rebuild the Codespace OR run `sudo bash .devcontainer/init-firewall.sh` to pick up the new entries. PR #9's policy-reset-before-flush work makes the in-place re-run safe.
