### PR TITLE
fix(firewall): remove sentry.io and statsig.com from allowlist

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -164,9 +164,15 @@ CRITICAL_DOMAINS=(
 #      arbitrary data), so this surface increase is bounded.
 OPTIONAL_DOMAINS=(
     # --- Group 1: tooling endpoints ---
+    # Note: upstream Anthropic init-firewall.sh also includes `sentry.io` and
+    # `statsig.com` here (Sentry error reporting, Statsig feature flags used
+    # by claude-code). Omitted in this fork — both endpoints are explicitly
+    # designed to ingest arbitrary client-side data, which contradicts the
+    # template's stated posture of minimizing exfiltration surface. The
+    # tooling continues to function; users may see periodic "no route to
+    # host" errors when claude-code tries to phone home, which is the
+    # firewall doing its job. Documented in README troubleshooting.
     "registry.npmjs.org"
-    "sentry.io"
-    "statsig.com"
     "marketplace.visualstudio.com"
     "vscode.blob.core.windows.net"
     "update.code.visualstudio.com"

--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ sudo /workspaces/safer-codespace/.devcontainer/init-firewall.sh
 
 **Solution:** Outbound SSH is restricted to hosts in the firewall allowlist, not blanket-allowed. GitHub is included automatically via the `api.github.com/meta` fetch; other SSH hosts must be added explicitly. Resolve the host's IP and add it to `.devcontainer/init-firewall.sh` alongside the other optional domains, then rebuild the container. Unlike GitHub, GitLab and Bitbucket do not publish a stable meta endpoint, so their IP ranges have to be maintained manually.
 
+**Problem:** Periodic `no route to host` errors from `claude` or related tooling
+
+**Solution:** This fork removes `sentry.io` (error reporting) and `statsig.com` (feature flags) from the firewall allowlist — both endpoints are explicitly designed to ingest arbitrary client-side data, which we treat as exfiltration surface. The tooling still functions; the error lines are the firewall blocking telemetry calls, which is intentional. If you need these endpoints for a specific workflow, add them back to `OPTIONAL_DOMAINS` in `.devcontainer/init-firewall.sh` and rebuild.
+
 **For temporary debugging:** Disable the firewall (resets on container restart):
 ```bash
 sudo iptables -F


### PR DESCRIPTION
The 2026-05-15 review pass flagged `sentry.io` and `statsig.com` as odd inclusions in `OPTIONAL_DOMAINS`. Both endpoints are explicitly designed to ingest arbitrary client-side data — for a template whose stated posture is minimizing exfiltration surface, allowlisting destinations whose entire purpose is "accept arbitrary payloads from clients" is a contradiction worth resolving.

Removes both from the allowlist. Claude Code, the LLM CLI, and other installed tools continue to function — the user-visible effect is periodic "no route to host" errors when the tools try to phone home, which is the firewall doing its job.

Documented in two places so future readers don't re-add them by reflex:

- Code comment in `OPTIONAL_DOMAINS` noting the upstream Anthropic divergence and the rationale.
- New troubleshooting entry in README.md explaining the expected error pattern so users don't file it as a bug.

**Precedent:** the SpecStory fix (PR #11, May 8) established the same pattern — telemetry blocked, tool functions, README documents the noise. This PR applies the same discipline to the next-most-obvious telemetry endpoints.

**Risk:** low. If a specific workflow turns out to need these endpoints, adding them back is a one-line change. The default posture should be strict; we can relax case-by-case.

**Manual validation** (CI can't exercise — script skips when `CI=true`): in a Codespace built from this branch, run `bash tests/codespace/verify-firewall.sh` — expect 10/10 OK (no regressions to existing controls; we're only removing entries, not changing anything the tests cover). Optional additional check: `claude --version` should still work (or run `claude` and confirm it starts).
