### PR TITLE
docs(readme): name the firewall's specific limitations honestly

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,13 @@ for domain in \
     # ... rest of domains
 ```
 
-**Limitations:** Cannot prevent exfiltration to allowed domains (e.g., GitHub). Works best with other layers.
+**Limitations:** The firewall blocks destinations, not request contents. Three specific gaps worth naming up front:
+
+*Exfiltration via allowlisted LLM endpoints.* Some allowlisted endpoints accept arbitrary text in API requests: `api.anthropic.com`, `generativelanguage.googleapis.com`, `models.inference.ai.azure.com`, `api.githubcopilot.com`. The firewall can only see destinations, not request contents, so a compromised agent could POST stolen data to any of them. The endpoints that authenticate via the auto-injected `GITHUB_TOKEN` don't even require attacker-supplied credentials. We accept this tradeoff because the tools don't work without these entries.
+
+*Exfiltration via GitHub itself.* GitHub's IP ranges must be in the allowlist for the repo to function. With the auto-injected `GITHUB_TOKEN`, a compromised agent can `git push` to an attacker-controlled fork, create a gist, or post comments with stolen content. The firewall does not close any of these channels; see "Why No GitHub CLI?" below for related discussion.
+
+*Enforcement is bounded by the container.* The `vscode` user has passwordless `sudo` (needed for `apt install` during container setup). A compromised agent could run `sudo iptables -F` to disable the firewall entirely, or `sudo apt install gh` to undo the `gh` exclusion. The defenses here are layers a user maintains, not enforcement against an agent already executing commands as them.
 
 #### 2. Content Segregation
 
@@ -289,11 +295,7 @@ Choose less powerful tools when possible:
 
 ### Why No GitHub CLI?
 
-The `gh` CLI is **intentionally excluded** as part of our security-first approach:
-
-- **Risk:** Could be used to exfiltrate data via issues, PRs, or gists
-- **Alternative:** Standard `git` commands handle most workflows
-- **If needed:** Install manually (`sudo apt install gh`) with full awareness of the risk
+The `gh` CLI is intentionally excluded from the devcontainer image. This is partial mitigation, not enforcement: `git push` to an attacker-controlled fork uses the same auto-injected `GITHUB_TOKEN` and works without `gh`. Treat the exclusion as a signal of intent and a small friction-raiser, not a closed channel. Standard `git` handles legitimate workflows; install `gh` manually with `sudo apt install gh` if needed.
 
 ### Learn More
 


### PR DESCRIPTION
Three claims in the README needed tightening to match what the controls actually do. No firewall changes — purely documentation.

## What changed

**Network Firewall "Limitations" line expanded from one sentence to three short paragraphs**, each naming a specific gap:

- *Exfiltration via allowlisted LLM endpoints.* `api.anthropic.com`, `generativelanguage.googleapis.com`, `models.inference.ai.azure.com`, `api.githubcopilot.com` accept arbitrary text in API requests. The firewall can't inspect TLS-encrypted bodies. The endpoints authenticating via the auto-injected `GITHUB_TOKEN` don't even require attacker credentials.
- *Exfiltration via GitHub itself.* GitHub's IP ranges must be in the allowlist for the repo to function. With the auto-injected token, `git push` to an attacker fork, gists, and PR/issue comments all work as exfil channels.
- *Enforcement is bounded by the container.* The `vscode` user has passwordless `sudo`, so `sudo iptables -F` disables the firewall and `sudo apt install gh` undoes the `gh` exclusion. The defenses are layers a user maintains, not enforcement against an actively malicious agent.

**"Why No GitHub CLI?" section rewritten** from the previous "intentionally excluded as part of our security-first approach" framing to an honest description: partial mitigation, not enforcement. `git push` works without `gh` and uses the same token. The exclusion is a friction-raiser and signal of intent, not a closed channel.

## Why this matters

The previous wording was the kind of security-marketing language a reader scans past without absorbing what's actually true. Naming the specific gaps up front lets someone evaluating this template for their own use:
- Know the LLM-endpoint exfil surface is real and intentional (we kept those endpoints because the tools don't work without them).
- Know GitHub-as-exfil is unresolved and won't be resolved by the `gh` exclusion alone.
- Know that an attacker who already has code execution as the `vscode` user can disable everything.

Aligns with the existing "Experimental" framing and the "Use at your own risk" closing line. Doesn't oversell.

## Companion to the 2026-05-15 review pass

These three specific phrasings came from the independent review documents in `temp/reviews/`. They were the three "honesty issues" with the highest impact-per-line-edited. Other findings from the same review pass already shipped as PRs #17 (allowlist reconciliation) and #18 (telemetry removal); this completes the Tier 2 backlog from that review.
