### PR TITLE
chore(devcontainer): retry apt-get to absorb transient install failures

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
     }
   },
   "postCreateCommand": {
-    "system": "sudo apt-get update && sudo apt-get install -y iptables ipset dnsutils aggregate && sudo ${containerWorkspaceFolder}/.devcontainer/init-firewall.sh",
+    "system": "bash ${containerWorkspaceFolder}/.devcontainer/setup-system.sh",
     "python": "pip install uv && uv tool install llm && llm install llm-github-models llm-anthropic llm-gemini && llm models default github/gpt-4.1",
     "node": "npm install -g @anthropic-ai/claude-code rust-just @earendil-works/pi-coding-agent",
     "go": "go install github.com/charmbracelet/glow/v2@latest"

--- a/.devcontainer/setup-system.sh
+++ b/.devcontainer/setup-system.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# System-level setup for the safer-codespace devcontainer.
+#
+# Installs the apt packages the firewall script depends on (iptables,
+# ipset, dnsutils, aggregate) and then runs init-firewall.sh.
+#
+# Why this is a script and not inline in devcontainer.json's
+# postCreateCommand: the apt step occasionally fails during Codespace
+# creation due to transient Debian mirror issues or a network blip
+# mid-transaction. When that happens the whole `system` entry aborts,
+# the firewall doesn't get installed, and the container comes up wide
+# open with the failure buried in the creation log. A small retry loop
+# absorbs the common transient-failure mode; doing it in bash is
+# legible, doing it in a chained JSON one-liner is not.
+#
+# CI handling is left to init-firewall.sh's own skip block (CI=true).
+# apt-get works fine in CI, just slow occasionally — no need to skip it
+# here.
+
+set -euo pipefail
+
+readonly APT_MAX_ATTEMPTS=3
+readonly APT_BACKOFF_SECONDS=5
+
+# Retry apt-get update + install with linear backoff.
+# A failure inside the `if` test does NOT trip set -e because the
+# command's exit status is being explicitly tested.
+for attempt in $(seq 1 "$APT_MAX_ATTEMPTS"); do
+    if sudo apt-get update && sudo apt-get install -y iptables ipset dnsutils aggregate; then
+        break
+    fi
+    if [ "$attempt" -lt "$APT_MAX_ATTEMPTS" ]; then
+        echo "apt-get attempt $attempt failed, retrying in ${APT_BACKOFF_SECONDS}s..."
+        sleep "$APT_BACKOFF_SECONDS"
+    else
+        echo "ERROR: apt-get failed after $APT_MAX_ATTEMPTS attempts"
+        exit 1
+    fi
+done
+
+# Run the firewall init script. set -e ensures we don't reach this if
+# apt failed all retries above.
+sudo "$(dirname "$0")/init-firewall.sh"


### PR DESCRIPTION
The `system` postCreateCommand chains `apt-get update && apt-get install && init-firewall.sh`. When apt hits a transient mirror issue or network blip mid-transaction, the whole chain aborts, the firewall never installs, and the container comes up wide open with the failure buried in the creation log.

Observed in practice on 2026-05-17 — a fresh Codespace came up with `iptables`, `ipset`, and `dig` absent and the OUTPUT chain at default ACCEPT. Recovery required manually re-running `apt-get` and `init-firewall.sh`.

**Fix:** extract the system setup into `.devcontainer/setup-system.sh` with a retry loop around the apt step (3 attempts, 5-second linear backoff, ~10s worst-case added latency). Firewall init runs after a successful apt round.

**Why a script rather than inline:** a JSON one-liner with a shell `for`-loop, conditional `||`, embedded `sleep`, and proper exit handling is the kind of thing nobody re-reads correctly. The script is also a natural home for future system setup steps if any are added.

**Manual validation** (CI can't exercise — the firewall script's `CI=true` skip block still applies via the script): tested locally with `bash -n` for syntax. Real-world validation will come from the next fresh Codespace build; if the apt mirror is healthy, the loop succeeds on attempt 1 and behaves identically to the previous inline command. The retry path only activates when apt actually flakes.
