### PR TITLE
fix(firewall): fail closed on incomplete setup (#22)

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -8,6 +8,44 @@ if [[ "${CI:-false}" == "true" ]]; then
     exit 0
 fi
 
+# --- Fail closed (issue #22) -------------------------------------------------
+# This script runs with egress ALLOWED during setup (it must fetch GitHub IP
+# ranges and resolve domains), and only switches to default-DROP at the end.
+# If it exits before completing — a command error (set -e), an explicit `exit 1`
+# on a bad precondition, or a signal such as SIGHUP from a terminal closing
+# mid-run — the container must be left LOCKED DOWN (egress blocked, loopback
+# only), never in the wide-open build-phase state. A security control fails
+# closed, not open. Normal completion sets SUCCESS=1 just before exit, making
+# the trap a no-op on success.
+#
+# Manual re-runs should be detached so a closing terminal cannot SIGHUP the
+# apply mid-flight:   setsid bash .devcontainer/init-firewall.sh
+SUCCESS=0
+fail_closed() {
+    echo "ERROR: firewall setup did not complete — locking down (fail closed)." >&2
+    # OUTPUT first so egress is blocked before anything else; best-effort on the
+    # rest (we are already on an error path and must not abort here).
+    iptables -P OUTPUT DROP  || true
+    iptables -P INPUT DROP   || true
+    iptables -P FORWARD DROP || true
+    iptables -F              || true
+    iptables -A INPUT  -i lo -j ACCEPT || true
+    iptables -A OUTPUT -o lo -j ACCEPT || true
+}
+on_exit() {
+    local rc=$?
+    [ "$SUCCESS" = 1 ] && exit 0
+    fail_closed
+    exit "$rc"
+}
+# Signals exit with a code; the single EXIT handler does the lockdown work,
+# so a signal can never bypass fail-closed and never double-runs it.
+trap on_exit EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+# -----------------------------------------------------------------------------
+
 # 1. Extract Docker DNS info BEFORE any flushing
 DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
 
@@ -363,3 +401,7 @@ if ! curl --connect-timeout 5 https://api.github.com/zen >/dev/null 2>&1; then
 else
     echo "Firewall verification passed - able to reach https://api.github.com as expected"
 fi
+
+# All rules applied and both reachability checks passed. Mark success so the
+# fail-closed EXIT trap becomes a no-op for this clean exit.
+SUCCESS=1

--- a/README.md
+++ b/README.md
@@ -266,6 +266,13 @@ This template uses **multiple redundant layers** rather than relying on any sing
 - **Allowed domains:** GitHub, npm, PyPI, Anthropic API, Google Gemini API, etc.
 - **Automatically configured** on container startup
 - **Validates rules** to ensure proper function
+- **Fails closed:** if `init-firewall.sh` cannot complete — a network error, a
+  bad precondition, or a signal such as SIGHUP from a terminal closing mid-run —
+  it locks the container down (egress blocked, loopback only) instead of leaving
+  it open. A security control must fail closed, not silently open. Re-run the
+  script to restore normal operation; for manual re-runs, detach so a closing
+  terminal cannot interrupt the apply mid-flight:
+  `setsid bash .devcontainer/init-firewall.sh`.
 
 **Test the firewall:**
 ```bash


### PR DESCRIPTION
## fix(firewall): fail closed on incomplete setup (#22)

`init-firewall.sh` runs with egress ALLOWED during setup (it must fetch GitHub IP
ranges and resolve domains) and only switches to default-DROP at the end. If it
exited before completing — a command error, an explicit `exit 1` on a bad
precondition, or a signal such as SIGHUP from a terminal closing mid-run — the
container was left wide open (`policy ACCEPT`, no rules), silently. A security
control must fail closed.

### Change

- An `EXIT`-with-success-flag trap (plus `HUP/INT/TERM`) in `init-firewall.sh`.
  On any exit that isn't an explicit success it locks the container down
  (`OUTPUT DROP` + loopback only). `SUCCESS=1` is set only after both
  reachability checks pass, so the trap is a no-op on a clean run. Signals
  `exit` into the single `EXIT` handler, so a signal can neither bypass
  fail-closed nor double-run it. Armed immediately after the CI-skip block, so
  even an early-setup failure fails closed; CI is unaffected (its `exit 0`
  precedes the trap).
- README: documents the fail-closed behavior and recommends `setsid` for manual
  re-runs.

Deliberately NOT in this PR: atomic `iptables-restore` application (a larger
refactor; the trap covers the high-value partial-application risk). Tracked as a
follow-up.

### Test evidence (local Dev Container, Docker Desktop, 2026-06-13)

**A — happy path unchanged:** `init-firewall.sh` exits 0, `policy DROP`,
`verify-firewall.sh` 11/13 (the 2 failures are the Azure-only wireserver/IMDS
checks that don't apply locally — see #28); all negative controls held.

**B — fails closed on injected mid-setup failure:**
```
TEST: forcing failure
ERROR: firewall setup did not complete — locking down (fail closed).
exit=1
Chain OUTPUT (policy DROP)        # was: policy ACCEPT (open) before this fix
```
Confirmed truly locked down, not partial:
```
$ iptables -L OUTPUT -n -v
ACCEPT  ...  out: lo  ...          # only loopback; interface-scoped
example: blocked - good
github:  blocked                   # even normally-allowed egress is denied
```
Recovery (`init-firewall.sh` re-run) restored normal operation: `exit=0`,
`policy DROP` with full ruleset.
