### PR TITLE
fix(devcontainer): re-apply firewall on container start (#24)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,5 +27,6 @@
     "node": "npm install -g @anthropic-ai/claude-code rust-just @earendil-works/pi-coding-agent",
     "go": "go install github.com/charmbracelet/glow/v2@latest"
   },
+  "postStartCommand": "bash ${containerWorkspaceFolder}/.devcontainer/reapply-firewall.sh",
   "remoteUser": "vscode"
 }

--- a/.devcontainer/reapply-firewall.sh
+++ b/.devcontainer/reapply-firewall.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -uo pipefail
+# Re-apply the egress firewall on container start (issue #24).
+#
+# LOCAL ONLY. On Codespaces we deliberately do NOT re-apply: the firewall blocks
+# the Codespaces network-backed Azure Storage filesystem, so re-arming it on a
+# resumed codespace re-triggers the stop-wedge and the container/workspace data
+# loss (issue #23, closed won't-fix). A resumed codespace therefore comes back
+# WITHOUT the firewall by design; run init-firewall.sh by hand only if you
+# accept that tradeoff.
+#
+# iptables rules live in the container's network namespace, which is recreated
+# on every container stop/start, so without this the firewall silently
+# disappears after a restart until re-run. init-firewall.sh fails closed
+# (issue #22), so a failed reapply leaves the container locked down, not open.
+if [ -n "${CODESPACES:-}" ]; then
+    echo "Codespaces detected - not re-applying firewall on start (see issue #23)."
+    exit 0
+fi
+
+echo "Local container start - re-applying firewall (issue #24)."
+exec sudo --preserve-env=GITHUB_TOKEN "$(dirname "$0")/init-firewall.sh"


### PR DESCRIPTION
## fix(devcontainer): re-apply firewall on container start, local only (#24)

iptables rules live in the container's network namespace, which is recreated on
every container stop/start — so after a restart the firewall silently
disappeared until manually re-run. You could be running agents in a container
you believe is sandboxed but isn't.

### Change

- New `.devcontainer/reapply-firewall.sh`: env-gated wrapper.
  - **Local:** `exec`s `init-firewall.sh` (sudo, `GITHUB_TOKEN` preserved) to
    re-apply the firewall on start.
  - **Codespaces:** deliberately skips. Re-arming the firewall on a resumed
    codespace would re-break the network-backed Azure Storage filesystem and
    re-trigger the stop-wedge / data loss (issue #23, closed won't-fix). Resumed
    codespaces come back unfirewalled by design.
- `devcontainer.json`: `postStartCommand` runs the wrapper on every start.

Pairs with #22: `init-firewall.sh` now fails closed, so a *failed* restart
reapply locks the container down rather than leaving it open. (Harmless
double-apply on first boot: postCreate + postStart both run the script; it is
idempotent and re-run safe.)

### Test evidence (local Dev Container, Docker Desktop, 2026-06-13)

- **C — Codespaces guard:** `CODESPACES=1 bash reapply-firewall.sh` → prints the
  skip message, `exit 0`, firewall untouched.
- **D — local reapply:** flushed to `policy ACCEPT` (simulating a fresh restart),
  ran the wrapper → `policy DROP` restored, `exit 0`.
- **Wiring:** rebuilt so `postStartCommand` registers.
- **Real stop/start:** `docker stop <container>` → "Reload Window" in VS Code
  (which fires `postStartCommand`) → **without any manual step**, `policy DROP`
  was back, and `verify-firewall.sh` showed all positive controls reachable and
  all negative controls blocked — i.e. a full working firewall, not a fail-closed
  lockdown. (The `learn.microsoft.com` positive-control flake is the known
  Akamai-rotation staleness issue #27; the wireserver/IMDS failures are the
  Azure-only checks #28 — both unrelated to this change.)
