### PR TITLE
chore: remove Azure wireserver/IMDS allows and their checks (#28)

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -107,29 +107,15 @@ for resolver in $resolvers; do
     iptables -A OUTPUT -p tcp --dport 53 -d "$resolver" -j ACCEPT
 done
 
-# Azure platform channels (Codespaces runs on Azure VMs). Evidence from
-# 2026-06-11 NFLOG capture: in-container platform components continuously
-# attempt TCP/80 to both of these and were being rejected, invisible to
-# tcpdump-on-eth0 (REJECTed packets never reach the interface):
-#   - 168.63.129.16: the Azure "wireserver" (VM fabric/orchestration channel).
-#     Azure's own guest hardening (legacy iptables *security* table, present
-#     in the Codespaces image) already restricts NEW connections here to
-#     uid 0, so this allow is effectively root-only.
-#   - 169.254.169.254: the Azure Instance Metadata Service (IMDS).
-# Stops of firewall-active codespaces wedged in ShuttingDown for 35 min-4 h
-# (6/6 observed) and post-wedge resumes destroyed container + workspace;
-# firewall-off controls stopped in ~2-3 min (2/2). NOTE (tested 2026-06-11):
-# allowing these two channels alone did NOT resolve the stop-wedge — a fresh
-# codespace with both rules active from boot still wedged. They are kept
-# because platform components demonstrably depend on them (continuous retry
-# stream otherwise) and the wireserver allow is root-only by Azure's own
-# guest hardening. The remaining continuously-rejected destination during
-# wedges was an Azure Storage endpoint (20.209.0.0/16 space, TCP/443) — the
-# open lead. See README "Known issues" for the stop-wedge status.
-# SECURITY NOTE: IMDS is a classic SSRF/credential target; allowing it is a
-# platform-functionality tradeoff, documented in the README threat model.
-iptables -A OUTPUT -d 168.63.129.16 -p tcp --dport 80 -j ACCEPT
-iptables -A OUTPUT -d 169.254.169.254 -p tcp --dport 80 -j ACCEPT
+# Note (issue #28): PR #21 previously allowed the Azure wireserver
+# (168.63.129.16) and IMDS (169.254.169.254) here, on the hypothesis that they
+# were part of the Codespaces stop handshake. Issue #23 disproved that — the
+# stop-wedge is the firewall starving the network-backed Azure Storage
+# filesystem, not these endpoints. The allows were therefore REMOVED: they
+# rested on a falsified premise, IMDS (169.254.169.254) is a classic
+# SSRF/credential-exfiltration target that contradicts this firewall's purpose,
+# and both are inert on the supported local-Docker path. Re-add only with
+# concrete evidence of a dependency.
 
 # Note: upstream init-firewall.sh has `iptables -A INPUT -p udp --sport 53 -j
 # ACCEPT` here to accept DNS responses. Removed in this fork — source ports

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ That's it! All tools are pre-installed and the security firewall is automaticall
 
 ### Running locally (VS Code + Docker Desktop)
 
-The same template runs on your own machine. Validated once (2026-06-11, macOS
-on Apple Silicon): the firewall comes up during postCreate, and
-`verify-firewall.sh` passes everything except the two Azure-only checks
-(wireserver, IMDS), which fail by design outside Azure (see issue #28).
+The same template runs on your own machine. The firewall comes up during
+postCreate and re-applies automatically on restart; `verify-firewall.sh` should
+pass locally (a `learn.microsoft.com` positive control may intermittently FAIL
+due to CDN IP rotation — see issue #27).
 
 1. Install and start [Docker Desktop](https://www.docker.com/products/docker-desktop/), plus the VS Code [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 2. Command Palette → **Dev Containers: Clone Repository in Container Volume...** → this repository.

--- a/tests/codespace/verify-firewall.sh
+++ b/tests/codespace/verify-firewall.sh
@@ -93,13 +93,6 @@ run_check "HTTPS to learn.microsoft.com (cloud/.NET docs)" "pass" \
 # browser reconnection, and clean stops all fail (see init-firewall.sh Group 3).
 run_check "HTTPS to global.rel.tunnels.api.visualstudio.com" "pass" \
     "curl --connect-timeout 5 -fsS -o /dev/null https://global.rel.tunnels.api.visualstudio.com/api/version"
-# Azure platform channels (see init-firewall.sh "Azure platform channels").
-# Wireserver requires root (Azure's legacy security-table rule drops non-root
-# NEW connections by design), hence sudo.
-run_check "HTTP to Azure wireserver 168.63.129.16 (as root)" "pass" \
-    "sudo curl --connect-timeout 5 -fsS -o /dev/null 'http://168.63.129.16/?comp=versions'"
-run_check "HTTP to Azure IMDS 169.254.169.254" "pass" \
-    "curl --connect-timeout 5 -fsS -o /dev/null -H 'Metadata: true' 'http://169.254.169.254/metadata/instance?api-version=2021-02-01'"
 
 echo
 echo "=== Negative controls (non-allowlisted destinations should be blocked) ==="


### PR DESCRIPTION
## chore: remove Azure wireserver/IMDS allows and their checks (#28)

PR #21 added scoped TCP/80 allows for the Azure wireserver (`168.63.129.16`) and
IMDS (`169.254.169.254`) on the hypothesis that they were part of the Codespaces
stop handshake. Issue #23 **disproved** that — the stop-wedge is the firewall
starving the network-backed Azure Storage filesystem, not these endpoints. So
the allows rested on a falsified premise.

Removing them is the posture-consistent choice:

- **IMDS is a textbook SSRF / credential-exfiltration target** — on a cloud VM it
  serves the instance's managed-identity tokens. Allowing egress to it on an
  unproven need directly contradicts what this firewall is for.
- Both endpoints are **inert on the supported local-Docker path** (no Azure
  fabric), so removal has no local effect except a cleaner verification.
- The only behavior change is on Codespaces (platform retries get rejected
  again), which is already best-effort and deprioritized per #23.

### Changes

- `init-firewall.sh`: removed the two `iptables -A OUTPUT ... ACCEPT` rules;
  left a rationale note so the deliberate absence is documented.
- `tests/codespace/verify-firewall.sh`: removed the two corresponding
  positive-control checks (the dev-tunnel check stays).
- `README.md`: local-use note no longer references Azure-only check exceptions;
  points at #27 for the intermittent `learn.microsoft.com` CDN-rotation flake.

### Test evidence (local Dev Container, 2026-06-13)

```
reapply exit=0
wireserver/IMDS rules gone - good
...
=== Summary ===
  Passed: 11
  Failed: 0
All firewall behavior checks passed.
```

`verify-firewall.sh` now runs 11 checks (was 13) and passes clean locally; all
negative controls still hold. Re-add the allows only with concrete evidence of a
real dependency.
