### PR TITLE
fix(firewall): lock down IPv6 egress (#25)

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -31,6 +31,13 @@ fail_closed() {
     iptables -F              || true
     iptables -A INPUT  -i lo -j ACCEPT || true
     iptables -A OUTPUT -o lo -j ACCEPT || true
+    # IPv6 too (issue #25): the allowlist is IPv4-only, so any v6 egress would
+    # bypass the firewall. Best-effort lockdown on the error path.
+    if command -v ip6tables >/dev/null 2>&1; then
+        ip6tables -P OUTPUT DROP  || true
+        ip6tables -P INPUT DROP   || true
+        ip6tables -P FORWARD DROP || true
+    fi
 }
 on_exit() {
     local rc=$?
@@ -360,6 +367,27 @@ iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 iptables -P OUTPUT DROP
+
+# --- IPv6: fail closed (issue #25) -------------------------------------------
+# The allowlist is built from A records (IPv4) only — no IPv6 destination is
+# ever allowlisted — so any IPv6 egress would necessarily bypass this firewall.
+# Lock IPv6 down to loopback only. If the container has no IPv6 route this is a
+# no-op; if it ever gains one (Docker enable_ipv6, a v6-capable host, a future
+# platform change), traffic cannot slip around the IPv4 rules. Done here at the
+# end (not during setup) so curl/dig in the build phase aren't delayed by v6
+# connect timeouts; the fail_closed trap covers IPv6 on the error path.
+if command -v ip6tables >/dev/null 2>&1; then
+    ip6tables -P INPUT DROP
+    ip6tables -P FORWARD DROP
+    ip6tables -P OUTPUT DROP
+    ip6tables -F
+    ip6tables -A INPUT  -i lo -j ACCEPT
+    ip6tables -A OUTPUT -o lo -j ACCEPT
+    echo "IPv6 egress locked down (loopback only)."
+else
+    echo "WARNING: ip6tables not available - cannot lock down IPv6. Verify no IPv6 route exists (ip -6 route)."
+fi
+# -----------------------------------------------------------------------------
 
 # First allow established connections for already approved traffic
 iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/tests/codespace/verify-firewall.sh
+++ b/tests/codespace/verify-firewall.sh
@@ -96,6 +96,10 @@ run_check "HTTPS to global.rel.tunnels.api.visualstudio.com" "pass" \
 
 echo
 echo "=== Negative controls (non-allowlisted destinations should be blocked) ==="
+# IPv6 must be locked down (issue #25): the allowlist is IPv4-only, so any v6
+# egress would bypass the firewall. Confirm the v6 OUTPUT policy is DROP.
+run_check "IPv6 OUTPUT policy is DROP (locked down)" "pass" \
+    "command -v ip6tables >/dev/null 2>&1 && sudo ip6tables -L OUTPUT -n | grep -q 'policy DROP'"
 # These prove the firewall actually denies what it claims to deny. We use
 # bash /dev/tcp probes for TCP checks (no application-layer involvement)
 # to avoid ambiguity between "firewall blocked it" and "app rejected us".


### PR DESCRIPTION
## fix(firewall): lock down IPv6 egress (#25)

The firewall configured `iptables` (IPv4) only. The allowlist is built entirely
from DNS **A records** — no IPv6 destination is ever allowlisted — so if the
container ever had a routable IPv6 address (Docker `enable_ipv6`, a v6-capable
host, a future platform change), every rule could be bypassed with plain IPv6
egress. The control's correctness shouldn't depend on an undocumented property
of the host network.

### Change

- `init-firewall.sh`: lock IPv6 down to loopback only (`ip6tables` policies →
  DROP, flush, allow `lo`). Done at the same point IPv4 switches to DROP — at the
  *end* of setup, not during — so the build-phase `curl`/`dig` aren't delayed by
  IPv6 connect timeouts (Happy Eyeballs still uses the working IPv4 path).
  Guarded by `command -v ip6tables` with a warning if absent.
- `fail_closed` (issue #22 trap) also locks IPv6 down, so a partway failure
  fails closed on both stacks.
- `verify-firewall.sh`: new negative control asserting the IPv6 OUTPUT policy is
  DROP.

No allowlisting of IPv6 is added — the posture is "block all v6 egress" because
nothing legitimate uses it (the allowlist is v4). If a real v6 dependency ever
appears, it would need AAAA-aware allowlisting, and breaking loudly is the
correct behavior until then.

### Test evidence (local Dev Container, 2026-06-13)

```
IPv6 egress locked down (loopback only).
$ ip6tables -L OUTPUT -n
Chain OUTPUT (policy DROP)
ACCEPT  ...  ::/0  ::/0            # loopback only
$ curl -6 https://example.com → blocked

=== Summary ===
  Passed: 12
  Failed: 0
All firewall behavior checks passed.
```

`verify-firewall.sh` now runs 12 checks (added the IPv6 DROP-policy control) and
passes clean locally; all negative controls hold.
