### PR TITLE
fix: drop learn.microsoft.com (rotating-CDN staleness) (#27)

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -265,7 +265,11 @@ OPTIONAL_DOMAINS=(
     "nodejs.org"
     # Other languages
     "docs.oracle.com"          # Java
-    "learn.microsoft.com"      # .NET, Azure docs, etc.
+    # learn.microsoft.com removed (issue #27): Akamai's large rotating A-record
+    # pool defeats IP-snapshot allowlisting (constant staleness), and its shared
+    # CDN IPs widen exfil surface to other Akamai-hosted content. It was
+    # convenience-only (url_to_markdown doc fetch). Re-add here AND in
+    # url_to_markdown.py ALLOWED_DOMAINS if you need MS Learn docs.
     # Frameworks
     "react.dev"
     "vuejs.org"

--- a/README.md
+++ b/README.md
@@ -383,6 +383,10 @@ Debugging tip: outbound packets REJECTed by the firewall never appear in `tcpdum
 
 **Solution:** This fork removes `sentry.io` (error reporting) and `statsig.com` (feature flags) from the firewall allowlist — both endpoints are explicitly designed to ingest arbitrary client-side data, which we treat as exfiltration surface. The tooling still functions; the error lines are the firewall blocking telemetry calls, which is intentional. If you need these endpoints for a specific workflow, add them back to `OPTIONAL_DOMAINS` in `.devcontainer/init-firewall.sh` and rebuild.
 
+**Problem:** an allowlisted documentation site intermittently fails to load
+
+**Solution:** The firewall allowlists IPs from a one-time DNS snapshot taken when `init-firewall.sh` runs. CDN-fronted doc sites (Akamai/Cloudflare/Fastly) rotate their A-records, so the live IP can drift off the snapshot and the connection is blocked — the same IP-cannot-express-hostname limit described for the storage backend in [issue #23](https://github.com/nicomarr/safer-codespace/issues/23). The doc-site allowlist (Group 2 in `init-firewall.sh`) is therefore **best-effort**: re-run `init-firewall.sh` to refresh the snapshot if a specific allowed doc site fails. `learn.microsoft.com` was removed outright (issue #27) as the worst offender (large Akamai pool) and because its shared CDN IPs widen the surface; re-add it there and in `cli-tools/url_to_markdown.py` if you need Microsoft Learn docs.
+
 **For temporary debugging:** Disable the firewall (resets on container restart):
 ```bash
 sudo iptables -F

--- a/cli-tools/url_to_markdown.py
+++ b/cli-tools/url_to_markdown.py
@@ -50,7 +50,8 @@ ALLOWED_DOMAINS: set[str] = {
 
     # Other languages
     'docs.oracle.com',  # Java
-    'learn.microsoft.com',  # .NET, etc
+    # learn.microsoft.com removed (issue #27) — kept in sync with the firewall
+    # allowlist; see .devcontainer/init-firewall.sh for the rationale.
 
     # Frameworks & Tools
     'react.dev',

--- a/tests/codespace/verify-firewall.sh
+++ b/tests/codespace/verify-firewall.sh
@@ -86,8 +86,10 @@ run_check "HTTPS to docs.python.org (Python docs)" "pass" \
     "curl --connect-timeout 5 -fsS -o /dev/null https://docs.python.org/3/"
 run_check "HTTPS to docs.claude.com (LLM/AI docs)" "pass" \
     "curl --connect-timeout 5 -fsS -o /dev/null https://docs.claude.com/"
-run_check "HTTPS to learn.microsoft.com (cloud/.NET docs)" "pass" \
-    "curl --connect-timeout 5 -fsS -o /dev/null https://learn.microsoft.com/"
+# Note (issue #27): no CDN-rotating doc site (e.g. learn.microsoft.com on Akamai)
+# is used as a positive control — a snapshot allowlist cannot reliably pass a
+# domain whose A-records rotate per query. docs.python.org and docs.claude.com
+# (stable CDNs) represent the doc tier here.
 # Codespaces connectivity plane (dev tunnels). GitHub's documented health check
 # endpoint for the tunnel service. Without this allowed, `gh codespace ssh`,
 # browser reconnection, and clean stops all fail (see init-firewall.sh Group 3).


### PR DESCRIPTION
## fix: stop snapshot-allowlisting a rotating CDN; drop learn.microsoft.com (#27)

`verify-firewall.sh` intermittently FAILed on `learn.microsoft.com`. Root cause
is structural, not a bug: the firewall allowlists IPs from a one-time DNS
snapshot taken at setup, but `learn.microsoft.com` is Akamai-fronted with a large
rotating A-record pool, so the live IP routinely drifts off the snapshot and the
connection is blocked. **IP-snapshot allowlisting cannot track per-query CDN
rotation** — the same IP-cannot-express-hostname limit documented for the storage
backend in #23.

Rather than build a disproportionate fix (dnsmasq-populated ipset) for an
optional doc site, we accept the structural limit and trim:

- **Removed `learn.microsoft.com` from the allowlist entirely** (not just the
  test). It was convenience-only (`url_to_markdown` doc fetch, not needed by the
  agents), the worst staleness offender, and its shared Akamai IPs widen the
  exfil surface to other Akamai-hosted content on those IPs. Removed from BOTH
  `init-firewall.sh` Group 2 and `cli-tools/url_to_markdown.py` `ALLOWED_DOMAINS`
  (kept in sync by design).
- **Removed its `verify-firewall.sh` positive control.** A snapshot allowlist
  can't reliably positive-test a rotating-CDN domain; `docs.python.org` and
  `docs.claude.com` (stable CDNs) represent the doc tier.
- **README:** documents the doc-site allowlist as best-effort (re-run
  `init-firewall.sh` to refresh the snapshot if a specific allowed doc site
  fails), with the same structural framing as #23.

The other large-pool CDN doc sites (`docs.oracle.com`, `dev.mysql.com`,
`azure.microsoft.com`) are left in place for now — only `learn.microsoft.com` was
observed flaking; the README notes the list is best-effort if further curation is
wanted later.

### Test evidence (local Dev Container, 2026-06-13)

```
reapply exit=0
learn.ms: blocked - good (removed)
docs.python.org: reachable - good
...
=== Summary ===
  Passed: 11
  Failed: 0
All firewall behavior checks passed.
```

`verify-firewall.sh` now runs 11 checks (dropped the flaky `learn.microsoft.com`
positive control) and passes deterministically; `learn.microsoft.com` is now
blocked as expected; kept doc sites still reachable; all negatives hold.
