### PR TITLE
chore(ci): least-privilege permissions; remove dead inputs (#26)

### DIFF
--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -7,16 +7,10 @@ on:
   pull_request:
     branches: [ "main" ]
   workflow_dispatch:
-    # Manual trigger with inputs so users can control smoke testing from the UI
-    inputs:
-      run_smoke:
-        description: 'Run smoke tests inside the built container (true/false)'
-        required: false
-        default: 'true'
-      smoke_command:
-        description: 'Command to run inside the built container for smoke testing'
-        required: false
-        default: 'python --version'
+
+# Minimal token scope (issue #26): this workflow only checks out and builds.
+permissions:
+  contents: read
 
 jobs:
   build-devcontainer:
@@ -30,7 +24,3 @@ jobs:
         with:
           imageName: 'safer-codespaces-devcontainer'
           push: never
-
-      - name: Smoke check
-        run: |
-          echo "Devcontainer build step completed (see previous step logs for details)."

--- a/.github/workflows/llm-tool-test.yml
+++ b/.github/workflows/llm-tool-test.yml
@@ -7,6 +7,11 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
     # Manual trigger for on-demand testing
+
+# Minimal token scope (issue #26).
+permissions:
+  contents: read
+
 jobs:
   llm-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/network-connectivity-test.yml
+++ b/.github/workflows/network-connectivity-test.yml
@@ -9,6 +9,10 @@ on:
   workflow_dispatch:
     # Manual trigger for on-demand testing
 
+# Minimal token scope (issue #26).
+permissions:
+  contents: read
+
 jobs:
   connectivity-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## chore(ci): least-privilege permissions; remove dead injection-prone inputs (#26)

Aligns the workflows with the GitHub Actions security guidance in CLAUDE.md.

### Changes

- **`permissions: contents: read`** added (top-level) to all three workflows
  (`devcontainer-build`, `llm-tool-test`, `network-connectivity-test`). They only
  check out the repo and build/test, so the `GITHUB_TOKEN` should not get the
  repository default (often read-write). Least privilege.
- **Removed the dead, injection-shaped `workflow_dispatch` inputs**
  (`run_smoke`, `smoke_command`) and the no-op "Smoke check" step from
  `devcontainer-build.yml`. The inputs were never referenced; `smoke_command`
  ("Command to run inside the built container") is a foot-gun whose obvious future
  wiring — `runCmd: ${{ github.event.inputs.smoke_command }}` — is exactly the
  `${{}}`-expansion injection pattern CLAUDE.md's security section forbids. The
  build step itself is the smoke test.

### Deliberately NOT done

- **SHA-pinning the action refs** (`actions/checkout@v4`, `devcontainers/ci@v0.2`).
  On a private personal repo with three trivial workflows and no fork PRs, the
  tag-rewrite supply-chain scenario is marginal, and SHA pins rot silently without
  a Dependabot stream. Revisit if the repo goes public or gains contributors.

### Validation

Pure CI config change — the three workflows running green on this PR is the test.
No runtime/firewall behavior is touched.
